### PR TITLE
Add Dockerfile for use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+############################################################
+# Dockerfile to build Wasabi container
+# Based on Ubuntu
+############################################################
+
+FROM rustlang/rust:nightly as build
+
+RUN USER=root cargo new --bin wasabi
+WORKDIR /wasabi
+
+# Copy manifests
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./lib ./lib
+
+# Cache dependencies
+RUN cargo build --release
+RUN rm src/*.rs
+
+# Copy source tree
+COPY ./src ./src
+
+# Build for release
+RUN cargo build --release
+
+# Final base
+FROM debian:jessie-slim
+
+# Copy build artifact
+COPY --from=build /wasabi/target/release/wasabi .
+
+# Startup command
+ENTRYPOINT ["./wasabi"]


### PR DESCRIPTION
Add a dockerfile for easier use of Wasabi for users

Build the Docker image via the following

```
(ins)$ docker build --rm -t wasabi .
```

Once built, the user can use the container via the following

```
(ins)$ ls
> hello.c  hello.html  hello.js  hello.wasm

(ins)$ docker run --rm -t -v `pwd`:/data  wasabi /data/hello.wasm /data
```