### PR TITLE
Adding Support for new WebAssembly.Instance

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -120,27 +120,36 @@ let Wasabi = {
         global(location, op, globalIndex, value) {},
     }
 
-    const oldInstantiate = WebAssembly.instantiate;
-    WebAssembly.instantiate = (sourceBuffer, importObject) => {
+    const assertInstantiationPrecondition = function() {
         if (Wasabi.module.info === undefined || Wasabi.module.lowlevelHooks === undefined) {
             throw "missing static info or low-level hooks, did you include the Wasabi-generated JavaScript file?";
         }
+    }
 
+    const importObjectWithHooks = function(importObject) {
         for (const hook of Wasabi.HOOK_NAMES) {
             if (Wasabi.analysis[hook] === undefined) {
                 console.debug(hook, "hook not provided by Wasabi.analysis, add empty function as fallback");
                 Wasabi.analysis[hook] = defaultHooks[hook];
             }
         }
-
         let importObjectWithHooks = importObject || {};
         importObjectWithHooks.__wasabi_hooks = Wasabi.module.lowlevelHooks;
+        return importObjectWithHooks;
+    }
 
-        const result = oldInstantiate(sourceBuffer, importObjectWithHooks);
+    const wireInstanceExports = function(instance) {
+        Wasabi.module.exports = instance.exports;
+        Wasabi.module.table = instance.exports[Wasabi.module.info.tableExportName];
+    }
+
+    const oldInstantiate = WebAssembly.instantiate;
+    WebAssembly.instantiate = (sourceBuffer, importObject) => {
+        assertInstantiationPrecondition();
+        const result = oldInstantiate(sourceBuffer, importObjectWithHooks(importObject));
         // as soon as instance is available, save exports and table
         result.then(({module, instance}) => {
-            Wasabi.module.exports = instance.exports;
-            Wasabi.module.table = instance.exports[Wasabi.module.info.tableExportName];
+            wireInstanceExports(instance);
         });
         return result;
     };
@@ -153,7 +162,12 @@ let Wasabi = {
         return WebAssembly.instantiate(buffer, importObject);
     };
 
-    WebAssembly.Instance = () => {
-        throw "synchronous WebAssembly instantiation is not supported by Wasabi (Chrome does not support it for >4KB modules anyway, so we cannot execute Wasabi itself synchronously)"
+    const oldInstance = WebAssembly.Instance;
+    const newInstance = function(module, importObject) {
+        assertInstantiationPrecondition();
+        const instance = new oldInstance(module, importObjectWithHooks(importObject));
+        wireInstanceExports(instance);
+        return instance;
     };
+    WebAssembly.Instance = newInstance;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ Produces two files in <output_dir> (default: out/):
   - a JavaScript file with static analysis information, (Wasabi-internal) low-level hooks, Wasabi runtime, and Wasabi loader.
 
 Options:
-  --hooks=<comma-separated list>     Instrument ONLY for the given hooks.
+  --hooks=<comma-separated list>     Instrument ONLY for the given hooks (e.g. call, load, store, ...).
   --no-hooks=<comma-separated list>  Instrument for all BUT the given hooks.
                                      (Default: Instrument for all hooks.)"#,
                   error);


### PR DESCRIPTION
Instead of an error message, `WebAssembly.Instance` now works as expected. It is monkey patched in the very same way `WebAssembly.instantiate` and `WebAssembly.instantiateStreaming` work. 