### PR TITLE
Use Rust 1.41.1 in Docker (resolves #25)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Based on Ubuntu
 ############################################################
 
-FROM rust:1.31.1 as build
+FROM rust:1.41.1 as build
 
 RUN USER=root cargo new --bin wasabi
 WORKDIR /wasabi


### PR DESCRIPTION

Fixes #25 

I noticed that building a Docker image using the current Dockerfile raises some compile errors when it gets to compiling proc-macro-error. Changing the version of Rust helped fix it for me.