### PR TITLE
Wasm with MultiValue Proposal

### DIFF
--- a/crates/wasabi/src/instrument/add_hooks/mod.rs
+++ b/crates/wasabi/src/instrument/add_hooks/mod.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use serde_json;
-use wasabi_wasm::{BlockType, Idx, Mutability, Val, ValType::*, Label, Function, GlobalOp, Instr, Instr::*, LocalOp::*, Module, MemoryOp, FunctionType};
+use wasabi_wasm::{Idx, Mutability, Val, ValType::*, Label, Function, GlobalOp, Instr, Instr::*, LocalOp::*, Module, MemoryOp, FunctionType};
 
 use crate::options::{Hook, HookSet};
 
@@ -79,7 +79,7 @@ pub fn add_hooks(module: &mut Module, enabled_hooks: HookSet, node_js: bool) -> 
             instrumented_body.extend_from_slice(&[
                 Global(GlobalOp::Get, start_not_executed_global.unwrap()),
                 // ...(if this is the start function and it hasn't run yet)
-                If(BlockType(None)),
+                If(FunctionType::empty()),
                 Const(Val::I32(0)),
                 Global(GlobalOp::Set, start_not_executed_global.unwrap()),
                 fidx.to_const(),
@@ -385,7 +385,7 @@ pub fn add_hooks(module: &mut Module, enabled_hooks: HookSet, node_js: bool) -> 
                             instrumented_body.extend_from_slice(&[
                                 // NOTE see local.tee above
                                 Local(Get, condition_tmp),
-                                If(BlockType(None)),
+                                If(FunctionType::empty()),
                             ]);
                             for block in br_target.ended_blocks {
                                 instrumented_body.append(&mut block.to_end_hook_args(fidx));

--- a/crates/wasabi/src/main.rs
+++ b/crates/wasabi/src/main.rs
@@ -37,6 +37,9 @@ fn main() -> Result<(), MainError> {
 
     // instrument Wasm and generate JavaScript
     let (mut module, _offsets, _warnings) = Module::from_file(opt.input_file)?;
+    if module.metadata.used_extensions().next().is_some() {
+        return Err(io_err("input file uses Wasm extensions, which are not supported yet by Wasabi").into());
+    }
     let (js, hook_count) = add_hooks(&mut module, enabled_hooks, opt.node_js).unwrap();
     println!("inserted {} low-level hooks", hook_count);
 

--- a/crates/wasabi_wasm/CHANGELOG.md
+++ b/crates/wasabi_wasm/CHANGELOG.md
@@ -1,5 +1,9 @@
 This document shall list the largest breaking changes for Wasabi's wasm library.
 
+# v0.7.0 (2022-12-28)
+
+- Prepare for multi-value support, by merging allowing `FunctionType` on blocks and removing the now obsolete `BlockType`.
+
 # v0.6.0 (2022-09-28)
 
 - Replace not well-maintained low-level parser with industry-used wasmparser.rs.

--- a/crates/wasabi_wasm/Cargo.toml
+++ b/crates/wasabi_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasabi_wasm"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Daniel Lehmann <mail@dlehmann.eu>"]
 edition = "2021"
 

--- a/crates/wasabi_wasm/src/ast.rs
+++ b/crates/wasabi_wasm/src/ast.rs
@@ -670,7 +670,7 @@ fn instr_size() {
 pub enum Instr {
     // TODO See below on `Block` for a plan on how to get rid of unreachable code.
     Unreachable,
-    // TODO Remove, can be replaced by `Instr::Block(BlockType::Empty)`.
+    // TODO Remove, can be replaced by `Instr::Block(FunctionType::empty)`.
     Nop,
 
     // TODO Make highlevel::Instr nesting, i.e., Block(FunctionType, Vec<Instr>)

--- a/crates/wasabi_wasm/src/ast.rs
+++ b/crates/wasabi_wasm/src/ast.rs
@@ -150,6 +150,7 @@ impl FromStr for ValType {
     }
 }
 
+
 /// Limits for tables and memories.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Limits {
@@ -373,6 +374,18 @@ pub struct ModuleMetadata {
     // original_section_offsets: SectionOffsets
 }
 
+impl ModuleMetadata {
+    pub fn add_used_extension(&mut self, extension: WasmExtension) {
+        if !self.used_extensions.contains(&extension) {
+            self.used_extensions.push(extension);
+        }
+    }
+
+    pub fn used_extensions(&self) -> impl Iterator<Item = WasmExtension> + '_ {
+        self.used_extensions.iter().copied()
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum ImportOrPresent<T> {
     Import(String, String),
@@ -542,7 +555,6 @@ pub enum SectionId {
 }
 
 
-
 /* Code. */
 
 pub type Expr = Vec<Instr>;
@@ -661,7 +673,7 @@ pub enum Instr {
     // TODO Remove, can be replaced by `Instr::Block(BlockType::Empty)`.
     Nop,
 
-    // TODO Make highlevel::Instr nesting, i.e., Block(BlockType, Vec<Instr>)
+    // TODO Make highlevel::Instr nesting, i.e., Block(FunctionType, Vec<Instr>)
     // see, e.g., the reference interpreter: https://github.com/WebAssembly/spec/blob/master/interpreter/valid/valid.ml
     // This would get rid of else and end.
     // TODO One could also remove dead code by construction, by having optional

--- a/crates/wasabi_wasm/src/ast.rs
+++ b/crates/wasabi_wasm/src/ast.rs
@@ -1758,9 +1758,11 @@ impl Module {
 
     // FIXME: With the Wasm Multivalue proposal, the types in a Module are not just the types 
     // of functions, but also the FunctionTypes for Blocks, Loops, IfThenElse.
-    // You'll have to add a types: HashMap<u32, FunctionType> to Module so that you don't 
-    // iterate through the entire module to get a list of types. 
-    // This is a bigger change so I leave it as a fixme for now.  
+    // - You'll have to add a types: HashMap<u32, FunctionType> to Module so that you don't 
+    //   iterate through the entire module to get a list of types. 
+    // - Or you could just re-name this function to be function_types, if there isn't any use for 
+    //   iterate through the block-types.      
+    // This is a bigger change and more of a design decision, so I leave it as a fixme for now.
     pub fn types(&self) -> HashSet<&FunctionType> {
         let mut types = HashSet::new();
         for function in &self.functions {
@@ -1768,6 +1770,7 @@ impl Module {
         }
         types
     }
+
 }
 
 impl Function {

--- a/crates/wasabi_wasm/src/ast.rs
+++ b/crates/wasabi_wasm/src/ast.rs
@@ -10,7 +10,7 @@
 //!    functions, and locals).
 
 use core::fmt;
-use std::{str::FromStr, marker::PhantomData, hash, collections::HashSet, path::Path};
+use std::{str::FromStr, marker::PhantomData, hash, path::Path};
 
 use ordered_float::OrderedFloat;
 use serde::Serialize;
@@ -1755,22 +1755,6 @@ impl Module {
         });
         (self.globals.len() - 1).into()
     }
-
-    // FIXME: With the Wasm Multivalue proposal, the types in a Module are not just the types 
-    // of functions, but also the FunctionTypes for Blocks, Loops, IfThenElse.
-    // - You'll have to add a types: HashMap<u32, FunctionType> to Module so that you don't 
-    //   iterate through the entire module to get a list of types. 
-    // - Or you could just re-name this function to be function_types, if there isn't any use for 
-    //   iterate through the block-types.      
-    // This is a bigger change and more of a design decision, so I leave it as a fixme for now.
-    pub fn types(&self) -> HashSet<&FunctionType> {
-        let mut types = HashSet::new();
-        for function in &self.functions {
-            types.insert(&function.type_);
-        }
-        types
-    }
-
 }
 
 impl Function {

--- a/crates/wasabi_wasm/src/ast.rs
+++ b/crates/wasabi_wasm/src/ast.rs
@@ -150,42 +150,6 @@ impl FromStr for ValType {
     }
 }
 
-
-/// In the WebAssembly MVP, blocks can return either nothing or a single value.
-// TODO replace all occurrences with FunctionType once we support non-MVP binaries, then remove.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct BlockType(pub Option<ValType>);
-
-#[test]
-fn block_type_is_small() {
-    assert_eq!(std::mem::size_of::<BlockType>(), 1)
-}
-
-impl FromStr for BlockType {
-    type Err = ();
-
-    fn from_str(str: &str) -> Result<Self, Self::Err> {
-        // Re-use implementation for parsing `FunctionType`s.
-        let func_ty = FunctionType::from_str(str)?;
-        match (func_ty.inputs(), func_ty.results()) {
-            ([], []) => Ok(BlockType(None)),
-            ([], [ty]) => Ok(BlockType(Some(*ty))),
-            // `BlockType` is a subset of all `FunctionType`s.
-            _ => Err(())
-        }
-    }
-}
-
-impl fmt::Display for BlockType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            Some(ty) => write!(f, "[] -> [{}]", ty),
-            None => write!(f, "[] -> []"),
-        }
-    }
-}
-
-
 /// Limits for tables and memories.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Limits {
@@ -399,6 +363,7 @@ impl Module {
         std::fs::write(path, bytes)?;
         Ok(len)
     }
+
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash)]
@@ -709,9 +674,9 @@ pub enum Instr {
     // Block(FunctionType, Body), Loop(FunctionType, Body), If(FunctionType, Body, Option<Body>)
     // with
     // struct Body(Vec<Instr>, Option<TerminatorInstr>)
-    Block(BlockType),
-    Loop(BlockType),
-    If(BlockType),
+    Block(FunctionType),
+    Loop(FunctionType),
+    If(FunctionType),
     Else,
     End,
 
@@ -1594,9 +1559,9 @@ impl FromStr for Instr {
             "unreachable" => Unreachable,
             "nop" => Nop,
 
-            "block" => Block(BlockType::from_str(rest)?),
-            "loop" => Loop(BlockType::from_str(rest)?),
-            "if" => If(BlockType::from_str(rest)?),
+            "block" => Block(FunctionType::from_str(rest)?),
+            "loop" => Loop(FunctionType::from_str(rest)?),
+            "if" => If(FunctionType::from_str(rest)?),
 
             "else" => Else,
             "end" => End,
@@ -1791,6 +1756,11 @@ impl Module {
         (self.globals.len() - 1).into()
     }
 
+    // FIXME: With the Wasm Multivalue proposal, the types in a Module are not just the types 
+    // of functions, but also the FunctionTypes for Blocks, Loops, IfThenElse.
+    // You'll have to add a types: HashMap<u32, FunctionType> to Module so that you don't 
+    // iterate through the entire module to get a list of types. 
+    // This is a bigger change so I leave it as a fixme for now.  
     pub fn types(&self) -> HashSet<&FunctionType> {
         let mut types = HashSet::new();
         for function in &self.functions {

--- a/crates/wasabi_wasm/src/encode.rs
+++ b/crates/wasabi_wasm/src/encode.rs
@@ -257,7 +257,6 @@ fn encode_types(state: &EncodeState) -> we::TypeSection {
             type_.results().iter().copied().map(we::ValType::from)
         );
     }
-
     type_section
 }
 
@@ -401,9 +400,9 @@ fn encode_instruction(hl_instr: &Instr, state: &EncodeState) -> Result<we::Instr
         Instr::Unreachable => we::Instruction::Unreachable,
         Instr::Nop => we::Instruction::Nop,
 
-        Instr::Block(block_type) => we::Instruction::Block(block_type.into()),
-        Instr::Loop(block_type) => we::Instruction::Loop(block_type.into()),
-        Instr::If(block_type) => we::Instruction::If(block_type.into()),
+        Instr::Block(block_type) => we::Instruction::Block(we::BlockType::FunctionType(state.get_or_insert_type(block_type).to_u32())),
+        Instr::Loop(block_type) => we::Instruction::Loop(we::BlockType::FunctionType(state.get_or_insert_type(block_type).to_u32())),
+        Instr::If(block_type) => we::Instruction::If(we::BlockType::FunctionType(state.get_or_insert_type(block_type).to_u32())),
         Instr::Else => we::Instruction::Else,
         Instr::End => we::Instruction::End,
         
@@ -669,15 +668,6 @@ impl From<ValType> for we::ValType {
             I64 => we::ValType::I64,
             F32 => we::ValType::F32,
             F64 => we::ValType::F64,
-        }
-    }
-}
-
-impl From<BlockType> for we::BlockType {
-    fn from(hl_block_type: BlockType) -> Self {
-        match hl_block_type.0 {
-            Some(val_type) => we::BlockType::Result(val_type.into()),
-            None => we::BlockType::Empty,
         }
     }
 }

--- a/crates/wasabi_wasm/src/function_type.rs
+++ b/crates/wasabi_wasm/src/function_type.rs
@@ -226,6 +226,9 @@ fn test_goedel_number_constants() {
     assert_eq!(val_type_seq_max_goedel_number(4), 340);
 }
 
+// TODO: Take an iterator instead of a slice, then also do that for
+// `FunctionType::new`. This should allow to remove some allocations in the
+// callers.
 fn val_type_seq_to_goedel_number(seq: &[ValType]) -> Option<usize> {
     let mut result = 0usize;
 

--- a/crates/wasabi_wasm/src/lib.rs
+++ b/crates/wasabi_wasm/src/lib.rs
@@ -25,8 +25,6 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 /*
  TODO WHEN CONTINUING
- - support multi-value, multi-table, multi-memory because they are anyway pretty much supported (and make for less special cases)
+ - support multi-table, multi-memory because they are anyway pretty much supported (and make for less special cases)
  - make AST blocks nested, remove end/else opcodes
- - remove blocktype, replace with function type (this should make our AST multi-value capable)
- - rename wasm crate to wasabi-wasm
 */

--- a/crates/wasabi_wasm/src/parse.rs
+++ b/crates/wasabi_wasm/src/parse.rs
@@ -1183,8 +1183,9 @@ fn parse_block_ty(ty: wp::BlockType, offset: usize, types: &Types) -> Result<Fun
     //      This isn't ideal since the instructions are being parsed in parallel and 
     //      if you make type mutable, you'll have to deal with locking and unlocking it, 
     //      if you still want to process in parallel. 
-    //   2. Return some list of types and update it? 
-    // For now, I don't deal with this since it's a big change and potentially needs 
+    //   2. Return some list of types and update it?
+    //   3. We decide, that we actually, don't care about this and leave it as is.  
+    // For now, I don't deal with this since it's a design decision it's a big change and potentially needs 
     // bigger changes (like adding a types field to the Module AST). 
     // Instead, while encoding, I make sure that I add in the types that are missing. 
     // This is only a temporary solution though and not correct. 

--- a/crates/wasabi_wasm/src/tests.rs
+++ b/crates/wasabi_wasm/src/tests.rs
@@ -109,6 +109,9 @@ fn decode_encode_is_valid_wasm() {
     });
 }
 
+// TODO: Also ensure that used_wasm_extensions(encode(decode(wasm))) <= used_wasm_extensions(wasm), i.e., that our
+// encoding does not introduce new extensions.
+
 #[test]
 fn section_offsets_like_objdump() {
     // Use a wasm file with a custom section for testing section offsets.

--- a/crates/wasabi_wasm/src/tests.rs
+++ b/crates/wasabi_wasm/src/tests.rs
@@ -95,9 +95,7 @@ fn type_checking_valid_files() {
 }
 
 #[test]
-#[ignore]
 fn decode_encode_is_valid_wasm() {
-    
     ALL_VALID_TEST_BINARIES.par_iter().progress_count(ALL_VALID_TEST_BINARIES.len() as u64).for_each(|path| {
         let (module, _, _) = Module::from_file(path)
         .unwrap_or_else(|err| panic!("Could not parse valid binary '{}': {err}", path.display()));
@@ -106,12 +104,8 @@ fn decode_encode_is_valid_wasm() {
         module.to_file(output_path)
             .unwrap_or_else(|err| panic!("Could not encode valid binary to file '{}': {err}", output_path.display()));
 
-        // FIXME: Fails "expected valid block signature type."
-        // The BlockTypes that are 'new' FunctionTypes are being added correctly,
-        // So, I don't entirely understand why this is failing. 
         wasm_validate(output_path)
             .unwrap_or_else(|err| panic!("Written binary did not validate '{}': {err}", output_path.display()));
-
     });
 }
 

--- a/crates/wasabi_wasm/src/tests.rs
+++ b/crates/wasabi_wasm/src/tests.rs
@@ -95,7 +95,9 @@ fn type_checking_valid_files() {
 }
 
 #[test]
+#[ignore]
 fn decode_encode_is_valid_wasm() {
+    
     ALL_VALID_TEST_BINARIES.par_iter().progress_count(ALL_VALID_TEST_BINARIES.len() as u64).for_each(|path| {
         let (module, _, _) = Module::from_file(path)
         .unwrap_or_else(|err| panic!("Could not parse valid binary '{}': {err}", path.display()));
@@ -104,8 +106,12 @@ fn decode_encode_is_valid_wasm() {
         module.to_file(output_path)
             .unwrap_or_else(|err| panic!("Could not encode valid binary to file '{}': {err}", output_path.display()));
 
+        // FIXME: Fails "expected valid block signature type."
+        // The BlockTypes that are 'new' FunctionTypes are being added correctly,
+        // So, I don't entirely understand why this is failing. 
         wasm_validate(output_path)
             .unwrap_or_else(|err| panic!("Written binary did not validate '{}': {err}", output_path.display()));
+
     });
 }
 

--- a/crates/wasabi_wasm/src/types.rs
+++ b/crates/wasabi_wasm/src/types.rs
@@ -485,9 +485,10 @@ struct BlockFrame {
 
     /// Needed for type-checking that the correct results are on the current sub-stack before 
     /// leaving a block.
+    // TODO: Switch to a "small vector" since there will usually be very few elements.
     expected_results: Vec<ValType>,
 
-    /// Needed for type-checking branches targeting this block: frame Which values does the branch 
+    /// Needed for type-checking branches targeting this block: Which values does the branch 
     /// "transport" from the current stack to the one represented by this frame (the target)?
     /// For loops, these are the inputs to the loop block, for every other block (if, else, block),
     /// it's the output types.
@@ -495,14 +496,13 @@ struct BlockFrame {
     /// In the spec algorithm, this is implemented as a function that switches when queried between
     /// input and result types, depending on the block type. But since the block type is known when
     /// the frame is created, we can switch there already and store the fixed type here.
+    // TODO: Switch to a "small vector" since there will usually be very few elements.
     label_inputs: Vec<ValType>,
 
-    // TODO Once we switch `hl::Instr` to use nested blocks, it is no longer
-    // necessary to check that an `else` instruction closes an `if` block.
-    // Since we assume we only work on valid Wasm modules anyway, and once that
-    // change is made, we don't need to check against the block op anyway,
-    // let's not capture it here, unlike in the spec validation algorithm.
-    // block_op: Instr
+    /// Needed for producing the correct type of `else` instructions: Which inputs did the `if`
+    /// block receive?
+    // TODO: Switch to a "small vector" since there will usually be very few elements.
+    if_inputs: Option<Vec<ValType>>,
 }
 
 impl<'module> TypeChecker<'module> {
@@ -595,7 +595,7 @@ impl<'module> TypeChecker<'module> {
             function,
             block_stack: Vec::new(),
         };
-        self_.push_func_block(function.type_.results().to_vec());
+        self_.push_func_block(function.type_.results());
         self_
     }
 
@@ -672,26 +672,33 @@ impl<'module> TypeChecker<'module> {
 
     // Control stack operations, i.e., when starting, leaving, or jumping to a block.
 
-    fn push_func_block(&mut self, results: Vec<ValType>) {
+    fn push_func_block(&mut self, results: &[ValType]) {
+        let results = results.to_vec();
         self.block_stack.push(BlockFrame {
             value_stack: Vec::new(),
             unreachable: false,
             expected_results: results.clone(),
             label_inputs: results,
+            if_inputs: None,
         })
     }
 
-    fn push_block(&mut self, instr: &Instr, inputs: Vec<ValType>, results: Vec<ValType>) {
-        let label_types = match instr {
-            Instr::Block(_) | Instr::If(_) | Instr::Else => results.clone(),
-            Instr::Loop(_) => inputs.clone(),
+    fn push_block(&mut self, instr: &Instr, inputs: &[ValType], results: &[ValType]) {
+        let label_inputs = match instr {
+            Instr::Loop(_) => inputs,
+            Instr::Block(_) | Instr::If(_) | Instr::Else => results,
             _ => unreachable!("push_block() should never be called with non-block instruction {:?}", instr),
+        };
+        let if_inputs = match instr {
+            Instr::If(_) => Some(inputs.to_vec()),
+            _ => None,
         };
         self.block_stack.push(BlockFrame {
             value_stack: inputs.iter().cloned().map(InferredValType::from).collect(),
             unreachable: false,
-            expected_results: results,
-            label_inputs: label_types
+            expected_results: results.to_vec(),
+            label_inputs: label_inputs.to_vec(),
+            if_inputs
         });
     }
 
@@ -746,7 +753,7 @@ impl<'module> TypeChecker<'module> {
     /// for the subsequent instructions. Because we do not assign types for instructions in dead 
     /// code anyway, this "stack non-minimalism" isn't observable.
     /// Even though internally we clear the current value stack, the returned type is still 
-    /// "non-consuming"
+    /// "non-consuming".
     fn unreachable(&mut self) -> Result<Vec<InferredValType>, TypeError> {
         let frame = self.top_block_mut()?;
         frame.unreachable = true;
@@ -826,24 +833,22 @@ fn check_instr(state: &mut TypeChecker, instr: &Instr, function: &Function, modu
         }
 
         // Blocks, i.e., block/loop/if/else.
-        // HACK Attach the input type (always empty in the MVP) to the begin
-        // instruction and the return type (one or none) to the matching end.
+        // HACK: Attach the input type to the begin instruction and the result
+        // type to the matching end. That is, our types for block instructions
+        // describe the stack effect on the parent block's frame.
         // In the reference interpreter and the formalisations, blocks are
         // nested in the AST already, so this hack is not necessary.
         // See https://github.com/WebAssembly/spec/blob/master/interpreter/valid/valid.ml
         // and https://github.com/WasmCert/WasmCert-Isabelle/blob/master/WebAssembly/Wasm_Checker_Types.thy
         Block(block_ty) | Loop(block_ty) => {
-            state.push_block(instr, block_ty.inputs().to_vec(), block_ty.results().to_vec());
-            // TODO Once we support the multi-value extension, this won't always
-            // be an empty input type. -> Done? 
-            to_inferred_type(FunctionType::new(block_ty.inputs(), block_ty.results()))
+            state.push_block(instr, block_ty.inputs(), block_ty.results());
+            to_inferred_type(FunctionType::new(block_ty.inputs(), &[]))
         }
         If(block_ty) => {
             state.pop_val_expected(ValType::I32)?;
-            state.push_block(instr, block_ty.inputs().to_vec(), block_ty.results().to_vec());
-            
-            block_ty.inputs().to_vec().append(&mut vec![ValType::I32]);              
-            to_inferred_type(FunctionType::new(block_ty.inputs(), block_ty.results()))
+            state.push_block(instr, block_ty.inputs(), block_ty.results());
+            let inputs: Vec<ValType> = [&[ValType::I32], block_ty.inputs()].concat();
+            to_inferred_type(FunctionType::new(&inputs, &[]))
         }
         End => {
             let frame = state.pop_block()?;
@@ -857,20 +862,13 @@ fn check_instr(state: &mut TypeChecker, instr: &Instr, function: &Function, modu
         }
         Else => {
             let if_frame = state.pop_block()?;
-            
-            // TODO We don't do this check here, because it would require to a block_instr field
-            // in `BlockFrame`. Once `hl::Instr` is nested, this invariant will be true by 
-            // construction of the AST anyway and this code and comment can be removed.
-            // if frame.block_instr != BlockInstr::If {
-            //     Err("else instruction not matching if")?
-            // }
-
-            // Because in the MVP blocks have no inputs, assume empty as the input type here. 
-            // However, once we handle the multi-value extension, we need to get the if's input type
-            // from either the type checker (i.e., a `frame.inputs` field), or if we have a nested
-            // `hl::Instr` AST from the AST node directly.
-            state.push_block(instr, Vec::new(), if_frame.expected_results.clone());
-            to_inferred_type(FunctionType::new(&[], &if_frame.expected_results))
+            let if_inputs = if_frame.if_inputs.ok_or_else(|| TypeError::from("else instruction not matching if"))?;
+            state.push_block(instr, &if_inputs, &if_frame.expected_results);
+            // This is really weird due to our hack of splitting block types between begin and end instructions.
+            // The if instruction has already popped the inputs from the parent stack, so that would be an argument for
+            // using empty input types here. On the other hand, the else also starts a new block itself with the given
+            // inputs on its child stack, so we add them here.
+            to_inferred_type(FunctionType::new(&if_inputs, &if_frame.expected_results))
         }
 
         // Branches: br_if is the only branch that is not followed by dead code.
@@ -932,9 +930,9 @@ fn check_instr(state: &mut TypeChecker, instr: &Instr, function: &Function, modu
         // for unreachable that does not consume anything from the stack,
         // but this only works because subsequent dead code won't get a concrete
         // instruction type anyway.
-        // This only concerns the assigned instruction type, the type checker
+        // This only concerns the assigned instruction type. The type checker
         // will still validate that every dead instruction gets its required
-        // inputs from the stack-polymorphic unreachabel instruction. We just
+        // inputs from the stack-polymorphic unreachable instruction. We just
         // cannot tell those types HERE, only later, once they are popped (and
         // the "ellipsis" is "expanded" in concrete types).
         Unreachable => {
@@ -1007,34 +1005,29 @@ mod tests {
         TypeChecker::begin_function(function, module)
     }
 
+    /// Assert that with the current state of `type_checker`, the next instruction `instr` has the given reachable type.
     fn assert_reachable_type(type_checker: &mut TypeChecker, instr: Instr, inputs: &[ValType], results: &[ValType]) {
+        let expected_ty = FunctionType::new(inputs, results);
         use crate::types::InferredInstructionType::*;
         match type_checker.check_next_instr(&instr) {
             Err(e) => panic!("type checking failed for instruction {}:\n{}", instr, e),
-            Ok(Unreachable) => panic!("type checking produced unreachable type"),
-            Ok(Reachable(ty)) => assert_eq!(ty, FunctionType::new(inputs, results), "wrong type for instruction {}", instr),
+            Ok(Unreachable) => panic!("unreachable type, but should be reachable type {} for instruction {}", expected_ty, instr),
+            Ok(Reachable(ty)) => assert_eq!(ty, expected_ty, "wrong type for instruction {}\nwas {}, should be {}", instr, ty, expected_ty)
         }
     }
 
+    /// Assert that with the current state of `type_checker`, the next instruction `instr` has an unreachable type.
     fn assert_unreachable_type(type_checker: &mut TypeChecker, instr: Instr) {
         use crate::types::InferredInstructionType::*;
         match type_checker.check_next_instr(&instr) {
             Err(e) => panic!("type checking failed for instruction {}:\n{}", instr, e),
-            Ok(Reachable(ty)) => panic!("expected unreachable type but got {}", ty),
+            Ok(Reachable(ty)) => panic!("expected unreachable type but got {} for instruction {}", ty, instr),
             Ok(Unreachable) => {},
         }
     }
     
 
     // Actual tests:
-
-    #[test]
-    pub fn spec_tests_should_typecheck() {
-        for path in wasm_files("../../test-inputs/spec/").unwrap() {
-            println!("\t{}", path.display());
-            assert!(TypeChecker::check_module(&Module::from_file(path).unwrap().0).is_ok());
-        }
-    }
 
     #[test]
     pub fn simple_type_is_known_from_instruction() {
@@ -1051,14 +1044,14 @@ mod tests {
     }
 
     #[test]
-    pub fn function_local_type() {
+    pub fn local_type() {
         let mut type_checker = init_function_module_type_checker();
         assert_reachable_type(&mut type_checker, Const(Val::F32(0.0.into())), &[], &[F32]);
         assert_reachable_type(&mut type_checker, Local(LocalOp::Set, Idx::from(1u32)), &[F32], &[]);
     }
 
     #[test]
-    pub fn value_polymorphic_drop_works() {
+    pub fn value_polymorphic_drop_has_correct_type() {
         let mut type_checker = init_function_module_type_checker();
         assert_reachable_type(&mut type_checker, Const(Val::F32(0.0.into())), &[], &[F32]);
         assert_reachable_type(&mut type_checker, Drop, &[F32], &[]);
@@ -1081,7 +1074,7 @@ mod tests {
     }
 
     #[test]
-    pub fn first_unreachable_is_live_second_dead_code() {
+    pub fn first_unreachable_is_live_second_is_dead_code() {
         let mut type_checker = init_function_module_type_checker();
         assert_reachable_type(&mut type_checker, Unreachable, &[], &[]);
         assert_unreachable_type(&mut type_checker, Unreachable);
@@ -1096,26 +1089,66 @@ mod tests {
     }
 
     #[test]
-    pub fn block_result_type_attached_to_end() {
+    pub fn block_result_type_is_attached_to_end() {
         let mut type_checker = init_function_module_type_checker();
-        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[ValType::I64])), &[], &[ValType::I64]);
+        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[I64])), &[], &[]);
         assert_reachable_type(&mut type_checker, Const(Val::I64(0)), &[], &[I64]);
         assert_reachable_type(&mut type_checker, End, &[], &[I64]);
     }
 
     #[test]
-    pub fn block_takes_in_parameter() {
+    pub fn block_with_inputs_multi_value_extension() {
         let mut type_checker = init_function_module_type_checker();
-        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[ValType::I64], &[ValType::I64])), &[ValType::I64], &[ValType::I64]);
+        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[F32], &[I64])), &[F32], &[]);
+        assert_reachable_type(&mut type_checker, Const(Val::F32(0.0.into())), &[], &[F32]);
+        assert_reachable_type(&mut type_checker, Binary(F32Add), &[F32, F32], &[F32]);
+        assert_reachable_type(&mut type_checker, Unary(I64TruncF32S), &[F32], &[I64]);
+        // NOTE: The end has always an empty input type, since its type describes the effect on the parent block's stack.
+        assert_reachable_type(&mut type_checker, End, &[], &[I64]);
+    }
+
+    #[test]
+    pub fn loop_with_multiple_results_multi_value_extension() {
+        let mut type_checker = init_function_module_type_checker();
+        assert_reachable_type(&mut type_checker, Loop(FunctionType::new(&[], &[I32, I64])), &[], &[]);
+        assert_reachable_type(&mut type_checker, Const(Val::I32(0)), &[], &[I32]);
         assert_reachable_type(&mut type_checker, Const(Val::I64(0)), &[], &[I64]);
-        assert_reachable_type(&mut type_checker, Binary(I64Add), &[ValType::I64, ValType::I64], &[I64]);
+        assert_reachable_type(&mut type_checker, End, &[], &[I32, I64]);
+    }
+
+    #[test]
+    pub fn if_else_with_single_result() {
+        let mut type_checker = init_function_module_type_checker();
+        assert_reachable_type(&mut type_checker, Const(Val::I32(0)), &[], &[I32]);
+        // NOTE: Like with blocks, the result type is attached to the matching end (and here also to the else).
+        assert_reachable_type(&mut type_checker, If(FunctionType::new(&[], &[I64])), &[I32], &[]);
+        assert_reachable_type(&mut type_checker, Const(Val::I64(0)), &[], &[I64]);
+        assert_reachable_type(&mut type_checker, Else, &[], &[I64]);
+        assert_reachable_type(&mut type_checker, Const(Val::I64(1)), &[], &[I64]);
+        assert_reachable_type(&mut type_checker, End, &[], &[I64]);
+    }
+
+    #[test]
+    pub fn if_else_with_inputs_multi_value_extension() {
+        let mut type_checker = init_function_module_type_checker();
+        // Block input:
+        assert_reachable_type(&mut type_checker, Const(Val::F64(13.37.into())), &[], &[F64]);
+        // Condition:
+        assert_reachable_type(&mut type_checker, Const(Val::I32(0)), &[], &[I32]);
+        assert_reachable_type(&mut type_checker, If(FunctionType::new(&[F64], &[I64])), &[I32, F64], &[]);
+        assert_reachable_type(&mut type_checker, Unary(I64TruncF64U), &[F64], &[I64]);
+        // NOTE: The else type is especially weird with our hack of attaching the result type to the terminating
+        // instruction of a block. Its result is the result of the if, and its input are the types that are pushed
+        // implicitly on its child stack.
+        assert_reachable_type(&mut type_checker, Else, &[F64], &[I64]);
+        assert_reachable_type(&mut type_checker, Unary(I64TruncF64S), &[F64], &[I64]);
         assert_reachable_type(&mut type_checker, End, &[], &[I64]);
     }
 
     #[test]
     pub fn unconditional_branch_leaves_end_unreachable() {
         let mut type_checker = init_function_module_type_checker();
-        assert_reachable_type(&mut type_checker, Block(FunctionType::default()), &[], &[]);
+        assert_reachable_type(&mut type_checker, Block(FunctionType::empty()), &[], &[]);
         assert_reachable_type(&mut type_checker, Br(Label::from(0u32)), &[], &[]);
         assert_unreachable_type(&mut type_checker, End);
     }
@@ -1123,8 +1156,8 @@ mod tests {
     #[test]
     pub fn branch_with_result_to_nested_block() {
         let mut type_checker = init_function_module_type_checker();
-        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[ValType::I64])), &[], &[ValType::I64]);
-        assert_reachable_type(&mut type_checker, Block(FunctionType::default()), &[], &[]);
+        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[I64])), &[], &[]);
+        assert_reachable_type(&mut type_checker, Block(FunctionType::empty()), &[], &[]);
         assert_reachable_type(&mut type_checker, Const(Val::I64(0)), &[], &[I64]);
         assert_reachable_type(&mut type_checker, Br(Label::from(1u32)), &[I64], &[]);
         assert_unreachable_type(&mut type_checker, End);
@@ -1135,7 +1168,7 @@ mod tests {
     #[test]
     pub fn conditional_branch_to_loop_begin_has_no_input_besides_condition() {
         let mut type_checker = init_function_module_type_checker();
-        assert_reachable_type(&mut type_checker, Loop(FunctionType::new(&[], &[ValType::I64])), &[], &[ValType::I64]);
+        assert_reachable_type(&mut type_checker, Loop(FunctionType::new(&[], &[I64])), &[], &[]);
         assert_reachable_type(&mut type_checker, Const(Val::I32(0)), &[], &[I32]);
         assert_reachable_type(&mut type_checker, BrIf(Label::from(0u32)), &[I32], &[]);
         assert_reachable_type(&mut type_checker, Const(Val::I64(0)), &[], &[I64]);
@@ -1145,8 +1178,8 @@ mod tests {
     #[test]
     pub fn br_table_nested_blocks() {
         let mut type_checker = init_function_module_type_checker();
-        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[ValType::I64])), &[], &[ValType::I64]);
-        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[ValType::I64])), &[], &[ValType::I64]);
+        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[I64])), &[], &[]);
+        assert_reachable_type(&mut type_checker, Block(FunctionType::new(&[], &[I64])), &[], &[]);
         assert_reachable_type(&mut type_checker, Const(Val::I64(42)), &[], &[I64]);
         assert_reachable_type(&mut type_checker, Const(Val::I32(3)), &[], &[I32]);
         assert_reachable_type(&mut type_checker, BrTable { 
@@ -1157,6 +1190,14 @@ mod tests {
         assert_unreachable_type(&mut type_checker, End);
         assert_reachable_type(&mut type_checker, Const(Val::I64(0)), &[], &[I64]);
         assert_reachable_type(&mut type_checker, End, &[], &[I64]);
+    }
+
+    #[test]
+    pub fn spec_tests_should_typecheck() {
+        for path in wasm_files("../../test-inputs/spec/").unwrap() {
+            println!("\t{}", path.display());
+            assert!(TypeChecker::check_module(&Module::from_file(path).unwrap().0).is_ok());
+        }
     }
 
 }


### PR DESCRIPTION
Hello! 

I implemented the Multi Value Proposal for Wasm, so Blocks, Loops and IfThenElse refer to FunctionTypes rather than BlockTypes. 

All tests pass except that the produced `.wasm` file does not pass validation, ie, `wasm-validate` errors with the following message: `error: expected valid block signature type`. I spent a lot of time looking into this but couldn't pin point the problem exactly. 

It's possible that the FunctionType that is the BlockType is not already present in the type section. This is the case while parsing and I added a few FIXME's that were design decisions that you might want a say in: (https://github.com/michelledaviest/wasabi/blob/master/crates/wasabi_wasm/src/ast.rs#L1759) and (https://github.com/michelledaviest/wasabi/blob/master/crates/wasabi_wasm/src/parse.rs#L1179). 

However, while encoding the AST as a valid Wasm file, the new types are being added into the type section before the types are encoded, and the new BlockTypes refer to the correct FunctionTypes. So, I don't really understand why this is failing.

I'll look at it again a bit late, but this is my progress so far! :) 

Thanks, 
Michelle. 