### PR TITLE
Fix taint analysis select hook with example

### DIFF
--- a/examples/analyses/taint.js
+++ b/examples/analyses/taint.js
@@ -120,8 +120,10 @@
 
         select(location, cond, first, second) {
             values().pop();
-            values().pop();
-            values().pop();
+            const taint2 = ensureTaint(values().pop(), location);
+            const taint1 = ensureTaint(values().pop(), location);
+            if (cond) values().push(taint1);
+            else values().push(taint2);
         },
 
         begin(location, type) {

--- a/examples/taint/simple/select_taint.wat
+++ b/examples/taint/simple/select_taint.wat
@@ -1,0 +1,28 @@
+(module
+    (import "imports" "output" (func $print (;0;) (param i32)))
+
+    (func $source (param i32))
+    (export "taint_source" (func $source))
+    (func $sink (param i32))
+    (export "taint_sink" (func $sink))
+
+    (func $f (local $locA i32)
+      i32.const 10
+      local.set $locA
+
+      ;; mark locA as tainted
+      local.get $locA
+      call $source
+
+      local.get $locA ;; select if true
+      i32.const 20    ;; select if false
+      
+      i32.const 1     ;; true
+      select
+      
+      ;; pass value to sink
+      call $sink
+    )
+
+    (start $f)
+)


### PR DESCRIPTION
#### Description

Fixed the `select` hook, which previously popped 3 values but failed to push any value, resulting in incorrect analysis. This update corrects the behavior of the `select` hook to ensure it pushes the expected value. Additionally, I have added a new example to demonstrate the corrected behavior.

#### Changes Made

- Corrected the `select` hook to push the appropriate value after popping 3 values.
- Added a new example showcasing the corrected behavior of the `select` hook.
